### PR TITLE
Introduce Rake and Minitest, and write tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-config/brakeman.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config/brakeman.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source 'https://rubygems.org'
 
 gemspec name: 'ruby-lsp-brakeman'
+
+group :development do
+  gem "minitest", "~> 5.25"
+  gem "rake", "~> 13.2"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "minitest/test_task"
+
+Minitest::TestTask.create
+
+task default: %i[test]

--- a/lib/ruby_lsp/ruby_lsp_brakeman/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_brakeman/addon.rb
@@ -41,12 +41,7 @@ module RubyLsp
         end
 
         @thread = Thread.new do
-          begin
-            @brakeman = Brakeman.run(app_path: global_state.workspace_path, support_rescanning: true)
-          rescue Brakeman::NoApplication
-            # Fallback to force_scan: true if it’s not a Rails application or when running tests.
-            @brakeman = Brakeman.run(app_path: global_state.workspace_path, support_rescanning: true, force_scan: true)
-          end
+          @brakeman = Brakeman.run(app_path: global_state.workspace_path, support_rescanning: true)
 
           notify("Initial Brakeman scan complete - #{@brakeman.filtered_warnings.length} warnings found")
 

--- a/test/ruby_lsp_brakeman/addon_test.rb
+++ b/test/ruby_lsp_brakeman/addon_test.rb
@@ -39,6 +39,10 @@ module RubyLsp
         with_server do |server, uri|
           server.process_message(
             id: 1,
+            method: "initialized",
+          )
+          server.process_message(
+            id: 2,
             method: "workspace/didChangeWatchedFiles",
             params: { changes: [ { uri: URI::File.build(path: tf.path).to_s, type: Constant::FileChangeType::CREATED } ] }
           )

--- a/test/ruby_lsp_brakeman/addon_test.rb
+++ b/test/ruby_lsp_brakeman/addon_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RubyLsp
+  module BrakemanLsp
+    class TestDefinition < Minitest::Test
+      def test_publich_diagnostic
+        diagnostics = generate_diagnostics_for_source(<<~'RUBY', { line: 2, character: 1 })
+          class SomeController < ApplicationController
+            def index
+              @any = ActiveRecord::Base.where("id = #{params[:id]}")
+            end
+          end
+        RUBY
+
+        assert_equal(1, diagnostics.size)
+
+        diagnostic = diagnostics.first
+        assert_equal(2, diagnostic.range.start.line)
+        assert_equal(0, diagnostic.range.start.character)
+        assert_equal(2, diagnostic.range.end.line)
+        assert_equal(1000, diagnostic.range.end.character)
+        assert_equal(Constant::DiagnosticSeverity::ERROR, diagnostic.severity)
+        assert_equal('https://brakemanscanner.org/docs/warning_types/sql_injection/', diagnostic.code_description.href)
+        assert_equal('Brakeman', diagnostic.source)
+        assert_equal(<<~'MESSAGE'.chomp, diagnostic.message)
+          [SQL Injection] Possible SQL injection.
+
+          Dangerous value: `params[:id]`
+        MESSAGE
+      end
+
+      def generate_diagnostics_for_source(source, position) # rubocop:disable Metrics/MethodLength
+        tf = Tempfile.open(['fake', '.rb']) do |fp|
+          fp.puts source
+          fp
+        end
+        with_server do |server, uri|
+          server.process_message(
+            id: 1,
+            method: "workspace/didChangeWatchedFiles",
+            params: { changes: [ { uri: URI::File.build(path: tf.path).to_s, type: Constant::FileChangeType::CREATED } ] }
+          )
+
+          result = pop_diagnostic(server)
+          result.params.diagnostics
+        end
+      end
+    end
+  end
+end

--- a/test/ruby_lsp_brakeman/addon_test.rb
+++ b/test/ruby_lsp_brakeman/addon_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 module RubyLsp
   module BrakemanLsp
     class TestDefinition < Minitest::Test
-      def test_publich_diagnostic
+      def test_publish_diagnostic
         diagnostics = generate_diagnostics_for_source(<<~'RUBY', { line: 2, character: 1 })
           class SomeController < ApplicationController
             def index

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
+require "minitest/autorun"
+require "tempfile"
+require "ruby_lsp/internal"
+require "ruby_lsp/test_helper"
+require "ruby_lsp/ruby_lsp_brakeman/addon"
+
+module Minitest
+  class Test
+    include RubyLsp::TestHelper
+
+    def pop_diagnostic(server)
+      result = server.pop_response
+      result = server.pop_response until result.is_a?(RubyLsp::Notification) && result.method == 'textDocument/publishDiagnostics'
+      result
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,12 @@ module Minitest
           force_scan: true
         YAML
         @config_file_created = true
+      else
+        require 'yaml'
+        options = YAML.safe_load_file @config_path, permitted_classes: [Symbol], symbolize_names: true
+        unless options[:force_scan]
+          flunk "Brakeman cannot be run in tests without force_scan: true. Please set it in config/brakeman.yml."
+        end
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,22 @@ module Minitest
   class Test
     include RubyLsp::TestHelper
 
+    def setup
+      @config_path = File.join(File.expand_path("..", __dir__), "config", "brakeman.yml")
+      unless File.exist?(@config_path)
+        FileUtils.mkdir_p(File.dirname(@config_path))
+        File.write(@config_path, <<~YAML)
+          ---
+          force_scan: true
+        YAML
+        @config_file_created = true
+      end
+    end
+
+    def teardown
+      File.delete(@config_path) if @config_file_created && File.exist?(@config_path)
+    end
+
     def pop_diagnostic(server)
       result = server.pop_response
       result = server.pop_response until result.is_a?(RubyLsp::Notification) && result.method == 'textDocument/publishDiagnostics'


### PR DESCRIPTION
Thank you for this awesome add-on! I’ve been wanting to create a Brakeman add-on.

I wrote tests for ruby-lsp-brakeman based on the tests for ruby-lsp and ruby-lsp-rails. I chose Minitest as the testing framework, but there's no strong preference for it.

Additionally, I addressed the following two points:

- Changed the behavior to fall back with force_scan: true when a Brakeman::NoApplication exception occurs during Brakeman.run execution.
- Modified the deactivate callback to terminate child threads.

The fallback with `force_scan: true` might be too forceful for test execution purposes. Please let me know if there's a better approach.

Thanks again for your excellent work on this add-on. Looking forward to any feedback or suggestions!