### PR TITLE
Change `code` to warning ID, not program code

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_brakeman/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_brakeman/addon.rb
@@ -150,7 +150,7 @@ module RubyLsp
               character: 1000, # "End of line"
             ),
           ),
-          code: warning.code,
+          code: warning.warning_code,
           code_description: Interface::CodeDescription.new(href: warning.link) # Does not work in VSCode?
         )
       end

--- a/test/ruby_lsp_brakeman/addon_test.rb
+++ b/test/ruby_lsp_brakeman/addon_test.rb
@@ -22,6 +22,7 @@ module RubyLsp
         assert_equal(2, diagnostic.range.end.line)
         assert_equal(1000, diagnostic.range.end.character)
         assert_equal(Constant::DiagnosticSeverity::ERROR, diagnostic.severity)
+        assert_equal(0, diagnostic.code)
         assert_equal('https://brakemanscanner.org/docs/warning_types/sql_injection/', diagnostic.code_description.href)
         assert_equal('Brakeman', diagnostic.source)
         assert_equal(<<~'MESSAGE'.chomp, diagnostic.message)


### PR DESCRIPTION
This was incorrect according to the spec, which would cause more strict clients (e.g. Helix) to raise an error.